### PR TITLE
Fix bluesky link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ A few things that I do:
 
 In the past I've reverse engineered and documented the **[Halo Infinite REST API](https://den.dev/blog/halo-api/)** (you can check out **[OpenSpartan](https://openspartan.com)** and **[Grunt](https://gruntapi.com)**), **[Zune REST API](https://den.dev/blog/zune-api/)**, and the **[Xbox media API](https://den.dev/blog/xbox-live-download-captures/)**, among others.
 
-You can find me on [**Bluesky**](https://bsky.app/den.dev), [**Mastodon**](https://mastodon.social/@localden), [**GitHub**](https://github.com/dend), [**LinkedIn**](https://www.linkedin.com/in/dendeli/), [**YouTube**](https://www.youtube.com/@DenDev), [**Stack Overflow**](https://stackoverflow.com/users/303696/den), and [**Hacker News**](https://news.ycombinator.com/user?id=dend).
+You can find me on [**Bluesky**](https://bsky.app/profile/den.dev), [**Mastodon**](https://mastodon.social/@localden), [**GitHub**](https://github.com/dend), [**LinkedIn**](https://www.linkedin.com/in/dendeli/), [**YouTube**](https://www.youtube.com/@DenDev), [**Stack Overflow**](https://stackoverflow.com/users/303696/den), and [**Hacker News**](https://news.ycombinator.com/user?id=dend).


### PR DESCRIPTION
Hey!
Came across your article about using Pi-hole, and found my way to your Github README and socials.  The bluesky link was just redirecting to `https://bsky.app/` because it was missing `.../profile/...`.

I don't know if it's weird to submit a pull request to someone's README :), but I thought you might like to know.


Cheers!